### PR TITLE
remove Robolectric from list of used libraries in Readme.md, since it…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Libraries used on the sample project
 * [Data binding](https://erikcaffrey.github.io/ANDROID-databinding-android/)
 * [Retrofit 2](http://square.github.io/retrofit/)
 * [RxJava & RxAndroid](https://github.com/ReactiveX/RxAndroid)
-* [robolectric](http://robolectric.org/)
 * [junit, mockito](http://mockito.org/)
 
 # Demo


### PR DESCRIPTION
…'s not used anymore